### PR TITLE
strip _ from reserved tag names

### DIFF
--- a/pyhtml.py
+++ b/pyhtml.py
@@ -298,7 +298,7 @@ class Tag(six.with_metaclass(TagMeta, object)):
 
     @property
     def name(self):
-        return self.__class__.__name__
+        return self.__class__.__name__.rstrip('_')
 
     def copy(self):
         return deepcopy(self)

--- a/pyhtml.py
+++ b/pyhtml.py
@@ -298,7 +298,7 @@ class Tag(six.with_metaclass(TagMeta, object)):
 
     @property
     def name(self):
-        return self.__class__.__name__.rstrip('_')
+        return self.__class__.__name__
 
     def copy(self):
         return deepcopy(self)
@@ -317,7 +317,7 @@ class Tag(six.with_metaclass(TagMeta, object)):
         _out.write(' ' * _indent)
 
         # Open tag
-        _out.write('<%s' % self.name)
+        _out.write('<%s' % self.name.rstrip('_'))
 
         self._write_attributes(_out, context)
 
@@ -343,7 +343,7 @@ class Tag(six.with_metaclass(TagMeta, object)):
                     _out.write(' ' * _indent)
 
             # Write closing tag
-            _out.write('</%s>' % self.name)
+            _out.write('</%s>' % self.name.rstrip('_'))
 
         return _out.getvalue()
 


### PR DESCRIPTION
Fix #11 

I originally tried fixing it by stripping the underscore in `Tag.name`, but for some reason I can't figure out that method is only called for the html, script and style tags in my tests. So I opted for a slightly dirtier fix in `Tag.render`