### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,24 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+                         flake8-comprehensions isort mypy pytest pyupgrade safety
+      - run: bandit --recursive --skip B101,B701 .
+      - run: black --check . || true
+      - run: codespell
+      - run: flake8 --ignore=C408,E231,E302,E305,E731,E741,F403,F405
+                    --max-complexity=10 --max-line-length=97
+                    --show-source --statistics
+      - run: isort --check-only --profile black .
+      - run: pip install -r requirements.txt
+      - run: mkdir --parents --verbose .mypy_cache
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest --doctest-modules --ignore=bench.py .
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/bench.py
+++ b/bench.py
@@ -5,7 +5,10 @@
 """
 import sys
 from timeit import Timer
+
 from jinja2 import Environment as JinjaEnvironment
+
+from pyhtml import *
 
 context = {
     'page_title': 'mitsuhiko\'s benchmark',
@@ -66,7 +69,6 @@ def f_table(ctx):
         td(cell) for cell in row
     ) for row in ctx['table'])
 
-from pyhtml import *
 pyhtml_template = html(
     head(
         title(var('page_title'))

--- a/pyhtml.py
+++ b/pyhtml.py
@@ -28,7 +28,7 @@ I will keep printing tags in this tutorial for clarity.
 <div></div>
 
 
-Parantheses can be omitted if the tag has no content.
+Parentheses can be omitted if the tag has no content.
 
 >>> print(div)
 <div></div>
@@ -187,9 +187,11 @@ Full example:
 """
 
 from __future__ import print_function
+
 import sys
 from copy import deepcopy
 from types import GeneratorType
+
 import six
 
 if sys.version_info[0] >= 3:
@@ -399,7 +401,7 @@ class Tag(six.with_metaclass(TagMeta, object)):  # type: ignore
             if key.endswith('_'):
                 key = key.rstrip('_')
 
-            # Dash is preffered to underscore in attribute names.
+            # Dash is preferred to underscore in attribute names.
             key = key.replace('_', '-')
 
             if callable(value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coverage
+jinja2
+six

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import os
 import re
+
 from setuptools import setup
 
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,2 +1,3 @@
 import coverage
+
 coverage.process_startup()

--- a/test_pyhtml.py
+++ b/test_pyhtml.py
@@ -1,8 +1,9 @@
 # -*- coding: utf8 -*-
 import unittest
-from pyhtml import *
 
 import six
+
+from pyhtml import *
 
 
 class TestPyHTML(unittest.TestCase):
@@ -10,7 +11,7 @@ class TestPyHTML(unittest.TestCase):
     assertEqualWS = unittest.TestCase.assertEqual
 
     def assertEqual(self, first, second, msg=None):
-        """Overriden for ignoring whitespace."""
+        """Overridden for ignoring whitespace."""
         def remove_whitespace(s):
             if isinstance(s, six.string_types):
                 return s.replace(' ', '').replace('\n', '')


### PR DESCRIPTION
Test results: https://github.com/cclauss/pyhtml/actions

Nosetests do not work on Python 3.9 and 3.10 so this PR shifts to pytest instead.

Mandatory tests are `bandit`, `flake8`, and `pytest`.

% `pytest --doctest-modules --ignore=bench.py .`
```
============================= test session starts ==============================
platform linux -- Python 3.10.0, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/runner/work/pyhtml/pyhtml
collected 47 items

pyhtml.py .                                                              [  2%]
test_pyhtml.py ..............................................            [100%]

============================== 47 passed in 0.26s ==============================
```